### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   quality:
     name: Run project test set
+    permissions:
+      contents: read
     uses: ./.github/workflows/python-tests.yml
     with:
       target_workflow: ./.github/workflows/python-tests.yml


### PR DESCRIPTION
Potential fix for [https://github.com/qaldak/docker-volume-backup/security/code-scanning/1](https://github.com/qaldak/docker-volume-backup/security/code-scanning/1)

To fix the issue, add a `permissions` block to the `quality` job in the workflow file. Based on the job's description and its apparent purpose (running tests), it likely only requires read access to the repository contents. Therefore, the `permissions` block should specify `contents: read`.

This change will ensure that the `quality` job adheres to the principle of least privilege, reducing the risk of unintended write access.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
